### PR TITLE
fix: fix wrong order bugs when converting multi-lines string

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
           <td>&#10004;</td>
         </tr>
         <tr>
-          <td>Rendering of text-only captions & subtitles</td>
+          <td>Rendering of text-only captions &amp; subtitles</td>
           <td>&#10004;</td>
           <td>&#10004;</td>
           <td>&#10004;</td>
@@ -138,51 +138,58 @@
     <div id="webvtt"></div>
     <script>
         function convert() {
-          input = document.getElementById("srt");
-          output = document.getElementById("webvtt");
-          srt = input.value;
-          webvtt = srt2webvtt(srt);
-          output.innerHTML = "<textarea rows=20 cols=80>"+webvtt+"</textarea>";
+          var input = document.getElementById("srt");
+          var output = document.getElementById("webvtt");
+          var srt = input.value;
+          var webvtt = srt2webvtt(srt);
+          output.innerHTML = "<textarea rows=20 cols=80>"
+                             + webvtt +
+                             "</textarea>";
         }
-        
+
         function srt2webvtt(data) {
           // remove dos newlines
           var srt = data.replace(/\r+/g, '');
           // trim white space start and end
           srt = srt.replace(/^\s+|\s+$/g, '');
-        
+
           // get cues
           var cuelist = srt.split('\n\n');
           var result = "";
-        
+
           if (cuelist.length > 0) {
             result += "WEBVTT\n\n";
             for (var i = 0; i < cuelist.length; i=i+1) {
               result += convertSrtCue(cuelist[i]);
             }
           }
-          
+
           return result;
         }
-        
+
         function convertSrtCue(caption) {
           // remove all html tags for security reasons
-          //srt = srt.replace(/<[a-zA-Z\/][^>]*>/g, ''); 
-          
+          //srt = srt.replace(/<[a-zA-Z\/][^>]*>/g, '');
+
           var cue = "";
           var s = caption.split(/\n/);
+
+          // concatenate muilt-line string separated in array into one
           while (s.length > 3) {
-            s[2] += '\n' + s.pop();
+              for (var i = 3; i < s.length; i++) {
+                  s[2] += "\n" + s[i]
+              }
+              s.splice(3, s.length - 3);
           }
 
           var line = 0;
-          
+
           // detect identifier
           if (!s[0].match(/\d+:\d+:\d+/) && s[1].match(/\d+:\d+:\d+/)) {
             cue += s[0].match(/\w+/) + "\n";
             line += 1;
           }
-          
+
           // get time strings
           if (s[line].match(/\d+:\d+:\d+/)) {
             // convert time string
@@ -199,12 +206,12 @@
             // file format error or comment lines
             return "";
           }
-          
+
           // get cue text
           if (s[line]) {
             cue += s[line] + "\n\n";
           }
-        
+
           return cue;
         }
     </script>


### PR DESCRIPTION
## *Bug Description*

Converting long multi-lines string would cause **wrong order** bugs.

![slice 1](https://user-images.githubusercontent.com/19472493/36354325-1f362062-1498-11e8-8228-719f959cc6a0.png)

## *Bug Reasons*

Wrong solution to  concatenate muilt-lines string separated in array into the one.

```js
173           var s = caption.split(/\n/);                                          
174           while (s.length > 3) {                                                
175             s[2] += '\n' + s.pop();                                             
176           }   
```
> JavaScript  Array `.pop` method would pop the last element in the array, just like stack, a `FILO` (firtst in last out) data structure.